### PR TITLE
No relative width for name/title

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -5,7 +5,7 @@
             <h3>{{ site.teamBlockTitle }}</h3>
             <p class="text-left animated hiding" data-animation="fadeInUp" data-delay="0">{{ site.aboutUs }}</p>
         </div>
-        <div class="col-lg-10 col-lg-offset-1 text-center">
+        <div class="col-lg-10 col-lg-offset-1 text-center members">
             <h4 class="text-left animated hiding appear-animation-trigger" data-animation="fadeInUp" data-delay="0">Organizers</h4>
             {% for teamMember in site.data.team %} {% if teamMember.team != null %}
             <div class="effect-wrapper col-md-4 col-sm-6 col-xs-12 cols-centered appear-animation">
@@ -32,7 +32,7 @@
             {% endif %} {% endfor %}
         </div>
         {% comment %}
-        <div class="col-lg-10 col-lg-offset-1 text-center">
+        <div class="col-lg-10 col-lg-offset-1 text-center members">
             <h4 class="text-left animated hiding appear-animation-trigger" data-animation="fadeInUp" data-delay="0">Program committee</h4>
             {% for teamMember in site.data.team %} {% if teamMember.subTeam != null %}
             <div class="effect-wrapper col-md-4 col-sm-6 col-xs-12 cols-centered appear-animation">

--- a/_sass/partials/_team.scss
+++ b/_sass/partials/_team.scss
@@ -6,6 +6,12 @@
 	    margin: 50px 0 20px;
 	    text-align: center;
 	}
+
+	.members {
+		.col-md-9,.col-xs-9,.col-md-8,.col-md-8 {
+			width: initial;
+		}
+	}
 }
 
 


### PR DESCRIPTION
This should resolve the problem on the team page with Imy's long list of profile links wrapping on hover.

Sorry, could only test in my browser, because I somehow have a bad setup for the Compass stuff