### PR TITLE
Move Code of Conduct to navigation bar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,6 +53,7 @@ navigationLinks:
  - {permalink: "/team/", text: "Team"}
  - {permalink: "/recordings/", text: "Recordings"}
  - {permalink: "/photos/", text: "Photos"}
+ - {permalink: "/cod/", text: "Code of Conduct"}
  # - {permalink: "/logistics/", text: "Logistics"}
  # - {permalink: "/hackathon/", text: "Hackathon"}
 bottomNavigationLinks:


### PR DESCRIPTION
It's important to have the code of conduct be as prominent as possible